### PR TITLE
Define __NR_perf_event_open if not found in asm/unistd.h

### DIFF
--- a/perf_swevent.c
+++ b/perf_swevent.c
@@ -13,6 +13,10 @@
 
 #define PERF_SWEVENT_MAX_FILE 980
 
+#ifndef __NR_perf_event_open
+#define __NR_perf_event_open   (__NR_SYSCALL_BASE+364)
+#endif
+
 typedef struct _supported_device {
   const char *device;
   const char *build_id;


### PR DESCRIPTION
$ grep -Rl __NR_perf_event_open ndk/android-ndk-r8b/platforms
ndk/android-ndk-r8b/platforms/android-9/arch-x86/usr/include/asm/unistd_32.h
ndk/android-ndk-r8b/platforms/android-14/arch-x86/usr/include/asm/unistd_32.h

Not found __NR_perf_event_open in android-ndk-r8b for arch-arm target.
