### PR TITLE
Update addresses for ISW13F, IS17SH, Sony Tablet S/P, SH-04E.

### DIFF
--- a/cred.c
+++ b/cred.c
@@ -25,6 +25,7 @@ typedef struct _supported_device {
 
 static supported_device supported_devices[] = {
   { "IS17SH", "01.00.04", 0xc01c66a8, 0xc01c5fd8 },
+  { "SH-04E", "01.00.02", 0xc008d86c, 0xc008d398 },
 };
 
 static int n_supported_devices = sizeof(supported_devices) / sizeof(supported_devices[0]);

--- a/mm.c
+++ b/mm.c
@@ -13,6 +13,7 @@ typedef struct _supported_device {
 } supported_device;
 
 static supported_device supported_devices[] = {
+  { "IS17SH", "01.00.04", 0xc0208a34 },
   { "SH-04E", "01.00.02", 0xc00e458c },
 };
 

--- a/perf_swevent.c
+++ b/perf_swevent.c
@@ -28,6 +28,7 @@ static supported_device supported_devices[] = {
   { "IS17SH",           "01.00.04"  , 0xc0ecbebc },
   { "URBANO PROGRESSO", "010.0.3000", 0xc0db6244 },
   { "ISW13F",           "V69R51I"   , 0xc09de374 },
+  { "Sony Tablet S",    "TISU0143"  , 0xc06d7714 },
   { "Sony Tablet P",    "TISU0144"  , 0xc06d9914 },
   { "SH-04E",           "01.00.02"  , 0xc0ed41ec },
 };

--- a/ptmx.c
+++ b/ptmx.c
@@ -16,9 +16,14 @@ static supported_device supported_devices[] = {
   { "F-11D",            "V24R40A"   ,         0xc1056998 },
   { "URBANO PROGRESSO", "010.0.3000",         0xc0dc0a10 },
   { "SCL21",            "IMM76D.SCL21KDALJD", 0xc0c71dc0 },
-  { "ISW13F",           "V69R51I",            0xc092e484 },
-  { "IS17SH",           "01.00.04",           0xc0a407bc },
-  { "Sony Tablet P",    "TISU0144",           0xc0671944 },
+
+  // ptmx_fops is 0xc09fc5fc but it doesn't work (kernel 2.6.39.4)
+  { "ISW13F",           "V69R51I",            0xc09fc5fc + 4 },
+
+  { "IS17SH",           "01.00.04",           0xc0edae90 },
+  { "Sony Tablet S",    "TISU0143",           0xc06e0d18 },
+  { "Sony Tablet P",    "TISU0144",           0xc06e2f20 },
+  { "SH-04E",           "01.00.02",           0xc0eed190 },
 };
 
 static int n_supported_devices = sizeof(supported_devices) / sizeof(supported_devices[0]);


### PR DESCRIPTION
SH-04E doesn't work yet.
